### PR TITLE
patch setup.cfg to include version, run tests, pip check

### DIFF
--- a/recipe/add_version.py
+++ b/recipe/add_version.py
@@ -1,0 +1,24 @@
+""" Adds (potentially) missing version to setup.cfg
+"""
+import pathlib, os, re
+
+setup_cfg = pathlib.Path(os.environ["SRC_DIR"]) / "setup.cfg"
+
+setup_cfg_text = setup_cfg.read_text()
+
+version_matches = re.findall(r"^version\s=\s(.*)$", setup_cfg_text, flags=re.M)
+
+if version_matches:
+    print("setup.cfg looks fine", version_matches)
+else:
+    print("setup.cfg needs a version")
+
+    setup_cfg_text = re.sub(
+        r"\[metadata\]",
+        f"[metadata]\nversion = {os.environ['PKG_VERSION']}\n",
+        setup_cfg_text
+    )
+
+    print(setup_cfg_text)
+
+    setup_cfg.write_text(setup_cfg_text)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,9 +10,13 @@ source:
   sha256: 7ae5ccaca427bafa9760ac3cd8f8c244bfc259794b5b6bb9db4dda2241575d09
 
 build:
-  number: 0
+  number: 1
   noarch: python
-  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv "
+  script:
+    - "cd '{{ RECIPE_DIR }}'"
+    - "{{ PYTHON }} add_version.py"
+    - "cd '{{ SRC_DIR }}'"
+    - "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv "
 
 requirements:
   host:
@@ -24,8 +28,17 @@ requirements:
     - more-itertools
 
 test:
+  source_files:
+    - test_zipp.py
+  requires:
+    - pip
+    # this is a downstream that has a version requirement on zipp
+    - importlib_metadata
   imports:
     - zipp
+  commands:
+    - python -m unittest test_zipp.py
+    - pip check
 
 about:
   home: https://github.com/jaraco/zipp


### PR DESCRIPTION
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

- fixes #8

This adds:
- a hack to patch in the version to `setup.cfg`
- a downstream with a version pin (`importlib_metadata`) and `pip check` to (hopefully) catch the issue in the future (if it persists)
- runs the tests (because why not)