### PR TITLE
Pin python>=3.8

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,14 +10,14 @@ source:
   sha256: 1876cb065531855bbe83b6c489dcf69ecc28f1068d8e95959fe8bbc77774c941
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: '{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv '
 
 requirements:
   host:
     - pip
-    - python >=3.7
+    - python >=3.8
     - setuptools >=56
     - wheel
     # Add upper bound to get around circular dependency
@@ -25,7 +25,7 @@ requirements:
     - setuptools_scm >=3.4.1,<7
     - toml
   run:
-    - python >=3.7
+    - python >=3.8
 
 test:
   source_files:


### PR DESCRIPTION
zipp v3.16 requires python 3.8 or later

https://github.com/jaraco/zipp/blob/main/NEWS.rst#v3160

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

zipp 3.16.0 removed python 3.7 compatibility, but the build of this package did not update the python pin properly. I'd recommend retracting build 0, if possible. It breaks in environments with python 3.7.